### PR TITLE
Adding GCC_EXE_SUFFIX to make-gcc-rpm.sh path to search for gcc executable

### DIFF
--- a/make-gcc-rpm.sh
+++ b/make-gcc-rpm.sh
@@ -58,7 +58,7 @@ fi
 
 BO_ROOT_DIR=`readlink -f $GCC_STAGEDIR`
 
-if [ -x $BO_ROOT_DIR/$GCC_INSTALL_RELDIR/bin/gcc ]; then
+if [ -x $BO_ROOT_DIR/$GCC_INSTALL_RELDIR/bin/gcc$GCC_EXE_SUFFIX ]; then
     echo "Found GCC $GCC_VERSION in $BO_ROOT_DIR/$GCC_INSTALL_RELDIR"
     GCC_TAG=`echo $GCC_VERSION | tr -d .`
 else


### PR DESCRIPTION
Fixing an issue in the rpm build script:
When defining GCC_EXE_SUFFIX in gcc-build-vars.sh,
make-gcc-rpm.sh is faling due to missing gcc executable.
The executable will be named differently in this case,
according to the value of GCC_EXE_SUFFIX.